### PR TITLE
Changed proto versions

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -30,13 +30,13 @@ static const int DATABASE_VERSION = 70510;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 80007;
+static const int PROTOCOL_VERSION = 80006;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 80006;
+static const int MIN_PEER_PROTO_VERSION = 80005;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
We never released 3.0.0.5 and so there was no 80006.  We have to maintain 80006 for this release (3.1.1.1) so wallet can talk to 80005 (3.0.0.4) wallets.