### PR TITLE
updated UI field to support larger kB3 / B3 transactions

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       3
 #define CLIENT_VERSION_MINOR       1
 #define CLIENT_VERSION_REVISION    1
-#define CLIENT_VERSION_BUILD       2
+#define CLIENT_VERSION_BUILD       3
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/fn-activity.h
+++ b/src/fn-activity.h
@@ -18,11 +18,11 @@
 
 //static const int64_t FUNDAMENTALNODEAMOUNT = (2500000 + 1)*COIN;//2500000;
 inline int64_t GetFNCollateral(int nHeight) {
-    if (nHeight > 85000)
-        return 20000000*COIN; //20 million
-    
     if (nHeight > 95000)
         return 15000000*COIN; //15 million
+
+    if (nHeight > 85000)
+        return 20000000*COIN; //20 million
     
     return 25000000*COIN; //25 million
 

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -72,7 +72,8 @@ int BitcoinUnits::amountDigits(int unit)
 {
     switch(unit)
     {
-    case KBTC: return 5; // 21,000 (# digits, without commas)
+    case KBTC: return 6; // 210,000 (# digits, without commas). 
+                         // previously set to 5. 5 limits kB3 transfers up to 99 million B3 whereas now 6 will support 999 million B3 transfer
     case BTC: return 10; // 21,000,000
     case mBTC: return 11; // 21,000,000,000
     case uBTC: return 14; // 21,000,000,000,000


### PR DESCRIPTION
Currently the UI limits to 5 places before the decimal, updating to 6.  See the details below.

5 places before decimal:
99999.XXXX  <-- the 5 limit when selecting kB3 in UI only allows to send 99 million B3 coins.  This causes problems in Coin Control when mixing inputs for staking.

6 places before decimal:
999999.XXXX <-- the 6 limit now will allow up to 999 million B3 coins which should be sufficient for Coin Control in the current supply.