### PR TITLE
FN 15000 kB3 Fix

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       3
 #define CLIENT_VERSION_MINOR       1
 #define CLIENT_VERSION_REVISION    1
-#define CLIENT_VERSION_BUILD       2
+#define CLIENT_VERSION_BUILD       3
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/fn-activity.h
+++ b/src/fn-activity.h
@@ -17,13 +17,13 @@
 
 
 //static const int64_t FUNDAMENTALNODEAMOUNT = (2500000 + 1)*COIN;//2500000;
-inline int64_t GetFNCollateral(int nHeight) {
-    if (nHeight > 85000)
-        return 20000000*COIN; //20 million
-    
+inline int64_t GetFNCollateral(int nHeight) {    
     if (nHeight > 95000)
         return 15000000*COIN; //15 million
     
+    if (nHeight > 85000)
+        return 20000000*COIN; //20 million
+
     return 25000000*COIN; //25 million
 
 }


### PR DESCRIPTION
The logic in fn-activity.h always hit the nHeight > 85000 logic block and the wallet required 20000 kB3 for any FN disintegration. Moved the 2 if statements around.

Also update client version to 3.1.1.3.