### PR TITLE
fixed kb3 decimal limit of 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+# ignore build
+build/
+B3Coin-Qt.app
+.qmake.stash
+Makefile

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -72,7 +72,7 @@ int BitcoinUnits::amountDigits(int unit)
 {
     switch(unit)
     {
-    case KBTC: return 5; // 21,000 (# digits, without commas)
+    case KBTC: return 6; // 210,000 (# digits, without commas)
     case BTC: return 10; // 21,000,000
     case mBTC: return 11; // 21,000,000,000
     case uBTC: return 14; // 21,000,000,000,000
@@ -84,7 +84,7 @@ int BitcoinUnits::decimals(int unit)
 {
     switch(unit)
     {
-    case KBTC: return 9;
+    case KBTC: return 8;
     case BTC: return 6;
     case mBTC: return 3;
     case uBTC: return 0;


### PR DESCRIPTION
Previously updated only one variable but the decimal portion also needed to be updated to fix the 5 digit limit of KB3. This new commit/PR should now fix the UI limit and allow users to enter KB3 values of greater than 5 digits (99999.). Limit is set to 6 which is 999,999 KB3 which is 999,999,000 million B3.